### PR TITLE
feat(brand): Implement CRUD pages for admin brand management

### DIFF
--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Create.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Create.cshtml
@@ -1,15 +1,16 @@
 ﻿@page
 @using ShahanStore.RazorPage.Infrastructure.ViewModels
-@model ShahanStore.RazorPage.Areas.Admin.Pages.Categories.CreateModel
+@model ShahanStore.RazorPage.Areas.Admin.Pages.Brands.CreateModel
+
 @{
     var siteSeo = new PageHeaderModel()
     {
-        Title = "افزودن دسته‌بندی",
+        Title = "افزودن برند",
         Breadcrumbs = new List<BreadcrumbItem>
         {
         new BreadcrumbItem { Text = "دشبرد", Url = "/Admin" },
-        new BreadcrumbItem { Text = "دسته‌بندی ها",Url = "/Admin/Categories"},
-        new BreadcrumbItem { Text = "افزودن دسته‌بندی", IsActive = true }
+        new BreadcrumbItem { Text = "برند ها",Url = "/Admin/Brands"},
+        new BreadcrumbItem { Text = "افزودن برند", IsActive = true }
         }
     };
 
@@ -24,12 +25,12 @@
         <form method="post" enctype="multipart/form-data">
             <div class="card">
                 <div class="card-header border-bottom border-dashed">
-                    <h4 class="card-title">اطلاعات مربوط به دسته‌بندی</h4>
+                    <h4 class="card-title">اطلاعات مربوط به برند</h4>
                 </div>
                 <div class="card-body">
                     <div class="row">
                         <div class="col-lg-6">
-                            @Html.EditorFor(c => c.Input.Title)
+                            @Html.EditorFor(c => c.Input.Name)
                         </div>
                         <div class="col-lg-6">
                             @Html.EditorFor(c => c.Input.Slug)
@@ -38,7 +39,10 @@
                             @Html.EditorFor(c => c.Input.BannerImg)
                         </div>
                         <div class="col-lg-6">
-                            @Html.EditorFor(c => c.Input.Icon)
+                            @Html.EditorFor(c => c.Input.Logo)
+                        </div>
+                        <div class="col-lg-12">
+                            @Html.EditorFor(c => c.Input.Description)
                         </div>
                         @Html.EditorFor(c => c.Input.SeoData)
                     </div>
@@ -46,7 +50,7 @@
 
                 <div class="card-footer border-top border-dashed text-end">
                     <div class="d-flex justify-content-end gap-1">
-                        <button type="submit" class="btn btn-primary">ایجاد دسته‌بندی</button>
+                        <button type="submit" class="btn btn-primary">ایجاد برند</button>
                         <a href="" class="btn btn-danger"> لغو</a>
                     </div>
                 </div>

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Create.cshtml.cs
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Create.cshtml.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ShahanStore.RazorPage.Infrastructure.RazorUtils;
+using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Commands.Brands;
+using ShahanStore.RazorPage.Services.Brands;
+using System.ComponentModel.DataAnnotations;
+
+namespace ShahanStore.RazorPage.Areas.Admin.Pages.Brands;
+
+public class CreateModel(IBrandService brandService) : BasePageModel
+{
+    [BindProperty]
+    public InputModel Input { get; set; }
+
+    public class InputModel
+    {
+        [Display(Name = "عنوان")]
+        [Required(ErrorMessage = "عنوان را وارد کنید!")]
+        public string Name { get; set; }
+
+        [Display(Name = "اسلاگ")]
+        [Required(ErrorMessage = "اسلاگ را وارد کنید!")]
+        public string Slug { get; set; }
+
+        [Display(Name = "بنر")]
+        public IFormFile? BannerImg { get; set; }
+
+        [Display(Name = "لوگو")]
+        public IFormFile? Logo { get; set; }
+
+        [Display(Name = "توضیحات")]
+        public string? Description { get; set; }
+
+        public SeoDataDto SeoData { get; set; }
+    }
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            ShowAlert("لطفاً تمام فیلدهای الزامی را پر کنید.", "Error");
+            return Page();
+        }
+        var command = new CreateBrandDto()
+        {
+            Name = Input.Name,
+            Slug = Input.Slug,
+            BannerImg = Input.BannerImg,
+            Logo = Input.Logo,
+            Description = Input.Description,
+            SeoData = Input.SeoData
+        };
+
+        var result = await brandService.CreateBrand(command);
+        if (result.IsSuccess)
+        {
+            return RedirectToPageWithAlert(result.Message, result, "Index");
+        }
+
+        ShowAlert(result.Message, "Error");
+        return Page();
+    }
+}

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Detail.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Detail.cshtml
@@ -1,0 +1,25 @@
+﻿@page "{id}"
+@using ShahanStore.RazorPage.Infrastructure.ViewModels
+@model ShahanStore.RazorPage.Areas.Admin.Pages.Brands.DetailModel
+@{
+    var siteSeo = new PageHeaderModel()
+    {
+        Title = "جزئیات برند",
+        Breadcrumbs = new List<BreadcrumbItem>
+        {
+        new BreadcrumbItem { Text = "دشبرد", Url = "/Admin" },
+        new BreadcrumbItem { Text = "برند ها",Url = "/Admin/Brands"},
+        new BreadcrumbItem { Text = $"جزئیات برند {Model.Brand.Name}", IsActive = true }
+        }
+    };
+
+    ViewData["Title"] = siteSeo.Title;
+}
+
+@await Html.PartialAsync("_PageTitleHead", siteSeo)
+<div class="row">
+
+    <partial name="_BrandDetail" model="@Model.Brand" />
+
+</div>
+<partial name="_Modal" />

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Detail.cshtml.cs
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Detail.cshtml.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ShahanStore.RazorPage.Infrastructure.RazorUtils;
+using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Queries.Brands;
+using ShahanStore.RazorPage.Services.Brands;
+
+
+namespace ShahanStore.RazorPage.Areas.Admin.Pages.Brands;
+
+public class DetailModel(IBrandService brandService) : BasePageModel
+{
+    [BindProperty(SupportsGet = true)]
+    public int PageId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int Take { get; set; } = 10;
+
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public Status? Status { get; set; }
+
+    public BrandDto? Brand;
+    public async Task<IActionResult> OnGet(Guid id)
+    {
+        Brand = await brandService.GetById(id);
+
+        if (Brand is null)
+        {
+            return NotFound(new { description = "برند مورد نظر یافت نشد." });
+        }
+        return Page();
+    }
+}

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Index.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Index.cshtml
@@ -1,16 +1,15 @@
 ﻿@page "{handler?}"
 @using ShahanStore.RazorPage.Infrastructure.ViewModels
 @using ShahanStore.RazorPage.Models.Bases
-@using ShahanStore.RazorPage.Models.Queries.Categories
-@model ShahanStore.RazorPage.Areas.Admin.Pages.Categories.IndexModel
+@model ShahanStore.RazorPage.Areas.Admin.Pages.Brands.IndexModel
 @{
     var siteSeo = new PageHeaderModel()
     {
-        Title = "دسته‌بندی ها",
+        Title = "برند ها",
         Breadcrumbs = new List<BreadcrumbItem>
         {
         new BreadcrumbItem { Text = "دشبرد", Url = "/Admin" },
-        new BreadcrumbItem { Text = "دسته‌بندی ها", IsActive = true }
+        new BreadcrumbItem { Text = "برند ها", IsActive = true }
         }
     };
 
@@ -30,7 +29,7 @@
                             <div class="row g-3">
                                 <div class="col-lg-6">
                                     <div class="position-relative">
-                                        <input asp-for="Search" type="text" class="form-control ps-4" placeholder="جستجو دسته بندی">
+                                        <input asp-for="Search" type="text" class="form-control ps-4" placeholder="جستجو برند">
                                         <i class="ti ti-search position-absolute top-50 translate-middle-y ms-2"></i>
                                     </div>
                                 </div>
@@ -50,7 +49,7 @@
                         </div>
                         <div class="col-lg-6">
                             <div class="text-md-end mt-3 mt-md-0">
-                                <a asp-page="Create" type="button" class="btn btn-dark waves-effect waves-light me-1"><i class="ti ti-plus me-1"></i>افزودن دسته‌بندی</a>
+                                <a asp-page="Create" type="button" class="btn btn-dark waves-effect waves-light me-1"><i class="ti ti-plus me-1"></i>افزودن برند</a>
                                 <button type="submit" class="btn btn-success  waves-effect waves-light"><i class="ti ti-filter me-1"></i> فیلترها</button>
                             </div>
                         </div>
@@ -58,18 +57,9 @@
                 </form>
             </div>
 
-
-            <partial name="_CategoryList" model="@Model.FilterResult.Data" />
-            @* <div id="categoryContainer">
-                             @await Html.PartialAsync("_CategoryList", Model.FilterResult?.Data) 
-                </div>*@
-
+            <partial name="_BrandList" model="@Model.FilterResult.Data" />
 
             <partial name="_Pagination" model="@Model.FilterResult" />
-            @*<div id="paginationContainer">
-                <partial name="_Pagination" model="@Model.FilterResult" />
-                 @await Html.PartialAsync("_Pagination", Model.FilterResult) 
-            </div>*@
 
         </div> <!-- end card-->
     </div><!-- end col -->

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Index.cshtml.cs
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/Index.cshtml.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ShahanStore.RazorPage.Infrastructure.RazorUtils;
+using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Commands.Brands;
+using ShahanStore.RazorPage.Models.Queries.Brands;
+using ShahanStore.RazorPage.Services.Brands;
+
+namespace ShahanStore.RazorPage.Areas.Admin.Pages.Brands;
+
+public class IndexModel : BaseRazorFilter<BrandFilterParams>
+{
+    private readonly IBrandService _brandService;
+
+    public IndexModel(IBrandService brandService)
+    {
+        _brandService = brandService;
+    }
+
+    [BindProperty(SupportsGet = true)]
+    public int PageId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int Take { get; set; } = 10;
+
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public Status? Status { get; set; }
+
+
+    public BrandFilterResult FilterResult { get; set; }
+    public async Task<IActionResult> OnGet()
+    {
+        FilterResult = await _brandService.GetByFilter(FilterParams);
+        return Page();
+    }
+
+
+    public async Task<IActionResult> OnGetEditPartial(Guid id)
+    {
+        var brand = await _brandService.GetById(id);
+        if (brand is null)
+        {
+            return NotFound(new { description = "دسته‌بندی مورد نظر یافت نشد." });
+        }
+        var modelForPartial = new EditBrandDto()
+        {
+            Id = brand.Id,
+            Name = brand.Name,
+            Slug = brand.Slug,
+            Description = brand.Description,
+            IsAvailable = brand.IsAvailable,
+            SeoData = brand.SeoData,
+        };
+
+        return Partial("_Edit", modelForPartial);
+    }
+    public async Task<IActionResult> OnPostEditPartial(EditBrandDto command)
+    {
+        var result = await _brandService.EditBrand(command);
+        return RedirectToPageWithAlert(result.Message, result, "Index");
+    }
+
+    public async Task<IActionResult> OnGetChangeBannerPartial(Guid id)
+    {
+        var brandDto = await _brandService.GetById(id);
+        if (brandDto is null)
+        {
+            return NotFound(new { description = "‌برند مورد نظر یافت نشد." });
+        }
+
+        var modelForPartial = new ChangeBrandBannerDto()
+        {
+            BrandId = brandDto.Id,
+            BannerImg = null
+        };
+
+        return Partial("_ChangeBrandBanner", modelForPartial);
+    }
+    public async Task<IActionResult> OnPostChangeBannerPartial(ChangeBrandBannerDto command)
+    {
+        var result = await _brandService.ChangeBanner(command);
+        return RedirectToPageWithAlert(result.Message, result, "Index");
+    }
+
+    public async Task<IActionResult> OnGetChangeLogoPartial(Guid id)
+    {
+        var brandDto = await _brandService.GetById(id);
+        if (brandDto is null)
+        {
+            return NotFound(new { description = "برند مورد نظر یافت نشد." });
+        }
+
+        var modelForPartial = new ChangeBrandLogoDto()
+        {
+            BrandId = brandDto.Id,
+            Logo = null
+        };
+
+        return Partial("_ChangeBrandLogo", modelForPartial);
+    }
+    public async Task<IActionResult> OnPostChangeLogoPartial(ChangeBrandLogoDto command)
+    {
+        var result = await _brandService.ChangeLogo(command);
+        return RedirectToPageWithAlert(result.Message, result, "Index");
+    }
+
+    public async Task<IActionResult> OnPostDeletePartial(Guid id)
+    {
+        return await AjaxTryCatch(() => _brandService.DeleteBrand(id),
+        reloadOnSuccess: true,
+        reloadOnError: false);
+    }
+}

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_Brand.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_Brand.cshtml
@@ -1,0 +1,79 @@
+﻿@using ShahanStore.RazorPage.Infrastructure
+@using ShahanStore.RazorPage.Infrastructure.ViewModels.Brands
+@model BrandTableRowVM
+
+<div class="table-responsive">
+    <table class="table table-hover text-nowrap mb-0">
+        <thead class="bg-light-subtle">
+            <tr>
+                <th>‌برند</th>
+                <th>رتبه مشتری (1-5)</th>
+                <th>وضعیت</th>
+                <th class="text-center" style="width: 120px;">فعالیت</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <div class="d-flex justify-content-start align-items-center gap-3">
+                        <div class="avatar-xl rounded-circle">
+                            @if (Model.Logo is null)
+                            {
+                                <img api-src="@($"{AppDirectories.BrandLogo}/Nabi_Logo.jpg")"
+                                     alt="@Model.Name"
+                                     class="img-fluid rounded-start"
+                                     modal-page="Index"
+                                     modal-page-handler="ChangeLogoPartial"
+                                     modal-route-id="@Model.Id" />
+                            }
+                            else
+                            {
+                                <img api-src="@($"{AppDirectories.BrandLogo}/{Model.Logo}")"
+                                     alt="@Model.Name"
+                                     class="img-fluid rounded-2"
+                                     modal-page="Index"
+                                     modal-page-handler="ChangeLogoPartial"
+                                     modal-route-id="@Model.Id" />
+                            }
+                        </div>
+                        <div class="d-flex flex-column">
+                            <span class="fw-medium text-nowrap">@Model.Name</span>
+                            <span class="text-dark fw-semibold">اسلاگ: <span class="fw-normal">@Model.Slug</span></span>
+                        </div>
+                    </div>
+                </td>
+                <td> <span class="badge p-1 bg-light text-dark fs-12 me-1"><i class="ti ti-star-filled align-text-top fs-14 text-warning me-1"></i> 4.5</span></td>
+                <td>
+                    @if (Model.IsAvailable)
+                    {
+                        <span class="badge bg-success-subtle text-success fs-12 p-1">فعال</span>
+
+                    }
+                    else
+                    {
+                        <span class="badge bg-danger-subtle text-danger fs-12 p-1">غیرفعال</span>
+
+                    }
+                </td>
+                <td class="pe-3">
+                    <div class="hstack gap-1 justify-content-end">
+                        <a asp-page="Detail" asp-route-id="@Model.Id" class="btn btn-soft-primary btn-icon btn-sm rounded-circle"><i class="ti ti-eye"></i> </a>
+                        <open-modal asp-page="Index"
+                                    asp-page-handler="EditPartial"
+                                    asp-route-id="@Model.Id"
+                                    modal-title="ویرایش برند"
+                                    class="btn btn-soft-warning btn-icon btn-sm rounded-circle">
+                            <i class="ti ti-pencil-cog"></i>
+                        </open-modal>
+                        <delete_Item asp-page="Index"
+                                     asp-page-handler="DeletePartial"
+                                     asp-route-id="@Model.Id"
+                                     class="btn btn-soft-danger btn-icon btn-sm rounded-circle">
+                            <i class="ti ti-trash"></i>
+                        </delete_Item>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_BrandDetail.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_BrandDetail.cshtml
@@ -1,0 +1,57 @@
+﻿@using ShahanStore.RazorPage.Infrastructure
+@using ShahanStore.RazorPage.Models.Queries.Brands
+@model BrandDto
+
+<div class="col-lg-12">
+    <div class="card">
+        <div class="row g-0 align-items-center">
+            <div class="col-md-4">
+                @if (Model.Logo is null)
+                {
+                    <img api-src="@($"{AppDirectories.BrandLogo}/Nabi_Logo.jpg")"
+                         alt="@Model.Name"
+                         class="img-fluid rounded-start"
+                         modal-page="Index"
+                         modal-page-handler="ChangeLogoPartial"
+                         modal-route-id="@Model.Id" />
+                }
+                else
+                {
+                    <img api-src="@($"{AppDirectories.BrandLogo}/{Model.Logo}")"
+                         alt="@Model.Name"
+                         class="img-fluid rounded-start"
+                         modal-page="Index"
+                         modal-page-handler="ChangeLogoPartial"
+                         modal-route-id="@Model.Id" />
+                }
+            </div>
+            <div class="col-md-4">
+                <div class="card-body">
+                    <h5 class="card-title">نام برند : @Model.Name</h5>
+                    <p class="card-text">اسلاگ : @Model.Slug</p>
+                    <p class="card-text"><small class="text-muted">آخرین به روز شده 3 دقیقه پیش</small></p>
+                </div> <!-- end card-body-->
+            </div> <!-- end col -->
+            <div class="col-md-4">
+                @if (Model.BannerImg is null)
+                {
+                    <img api-src="@($"{AppDirectories.BrandBanner}/Nabi_banner.jpeg")"
+                         alt="@Model.Name"
+                         class="img-fluid rounded-end"
+                         modal-page="Index"
+                         modal-page-handler="ChangeBannerPartial"
+                         modal-route-id="@Model.Id" />
+                }
+                else
+                {
+                    <img api-src="@($"{AppDirectories.BrandBanner}/{Model.BannerImg}")"
+                         alt="@Model.Name"
+                         class="img-fluid rounded-end"
+                         modal-page="Index"
+                         modal-page-handler="ChangeBannerPartial"
+                         modal-route-id="@Model.Id" />
+                }
+            </div> <!-- end col -->
+        </div> <!-- end row-->
+    </div> <!-- end card-->
+</div> <!-- end col-->

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_BrandList.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_BrandList.cshtml
@@ -1,0 +1,104 @@
+﻿@using ShahanStore.RazorPage.Infrastructure
+@using ShahanStore.RazorPage.Models.Queries.Brands
+@model List<BrandFilterData>
+
+@if (Model.Count > 0)
+{
+    <div class="table-responsive">
+        <table class="table table-hover text-nowrap mb-0">
+            <thead class="bg-light-subtle">
+                <tr>
+                    <th></th>
+                    <th>برند</th>
+                    <th>رتبه مشتری (1-5)</th>
+                    <th>وضعیت</th>
+                    <th class="text-center" style="width: 120px;">فعالیت</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td></td>
+                        <td>
+                            <div class="d-flex justify-content-start align-items-center gap-3">
+                                <div class="avatar-xl rounded-circle">
+                                    @if (item.Logo is null)
+                                    {
+                                        <img api-src="@($"{AppDirectories.BrandLogo}/Nabi_Logo.jpg")"
+                                             alt="@item.Name"
+                                             class="img-fluid rounded-start"
+                                             modal-page="Index"
+                                             modal-page-handler="ChangeLogoPartial"
+                                             modal-route-id="@item.Id" />
+                                    }
+                                    else
+                                    {
+                                        <img api-src="@($"{AppDirectories.BrandLogo}/{item.Logo}")"
+                                             alt="@item.Name"
+                                             class="img-fluid rounded-2"
+                                             modal-page="Index"
+                                             modal-page-handler="ChangeLogoPartial"
+                                             modal-route-id="@item.Id" />
+                                    }
+                                </div>
+                                <div class="d-flex flex-column">
+                                    <span class="fw-medium text-nowrap">@item.Name</span>
+                                    <span class="text-dark fw-semibold">اسلاگ: <span class="fw-normal">@item.Slug</span></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td> <span class="badge p-1 bg-light text-dark fs-12 me-1"><i class="ti ti-star-filled align-text-top fs-14 text-warning me-1"></i> 4.5</span></td>
+                        <td>
+                            @if (item.IsAvailable)
+                            {
+                                <span class="badge bg-success-subtle text-success fs-12 p-1">فعال</span>
+
+                            }
+                            else
+                            {
+                                <span class="badge bg-danger-subtle text-danger fs-12 p-1">غیرفعال</span>
+
+                            }
+                        </td>
+                        <td class="pe-3">
+                            <div class="hstack gap-1 justify-content-end">
+                                <a asp-page="Detail" asp-route-id="@item.Id" class="btn btn-soft-primary btn-icon btn-sm rounded-circle"><i class="ti ti-eye"></i> </a>
+                                <open-modal asp-page="Index"
+                                            asp-page-handler="EditPartial"
+                                            asp-route-id="@item.Id"
+                                            modal-title="ویرایش برند"
+                                            class="btn btn-soft-warning btn-icon btn-sm rounded-circle">
+                                    <i class="ti ti-pencil-cog"></i>
+                                </open-modal>
+                                <delete_Item asp-page="Index"
+                                             asp-page-handler="DeletePartial"
+                                             asp-route-id="@item.Id"
+                                             class="btn btn-soft-danger btn-icon btn-sm rounded-circle">
+                                    <i class="ti ti-trash"></i>
+                                </delete_Item>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-hover text-nowrap mb-0">
+            <thead class="bg-light-subtle text-center">
+                <tr>
+                    <th>برند</th>
+                </tr>
+            </thead>
+            <tbody class="text-center">
+                <tr>
+                    <td class="text-danger">موردی وجود ندارد</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+}

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_ChangeBrandBanner.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_ChangeBrandBanner.cshtml
@@ -1,0 +1,32 @@
+﻿@using ShahanStore.RazorPage.Models.Commands.Brands
+@model ChangeBrandBannerDto
+
+<form asp-page="Index" asp-page-handler="ChangeBannerPartial" method="post" enctype="multipart/form-data">
+    <div class="card">
+        <div class="card-header border-bottom border-dashed d-flex align-items-center">
+            <h4 class="header-title">بارگذاری پرونده</h4>
+        </div>
+        <!-- end card-body -->
+        <div class="card-body">
+            <div class="dz-message needsclick">
+                <i class="ti ti-cloud-upload h1 text-muted"></i>
+                <h3>برای بارگذاری کلیک کنید.</h3>
+            </div>
+            <p class="text-muted">
+                برای ویرایش بنر برند ،فایل مورد نظر را بارگذاری نمایید.
+            </p>
+            <div class="col-lg-6" hidden>
+                @Html.EditorFor(c => c.BrandId)
+            </div>
+            <div class="col-lg-6">
+                @Html.EditorFor(c => c.BannerImg)
+            </div>
+            <div class="card-footer border-top border-dashed text-end">
+                <div class="d-flex justify-content-end gap-1">
+                    <button type="submit" class="btn btn-primary">ویرایش ‌بنر</button>
+                    <a data-bs-dismiss="modal" class="btn btn-danger"> لغو</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_ChangeBrandLogo.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_ChangeBrandLogo.cshtml
@@ -1,0 +1,32 @@
+﻿@using ShahanStore.RazorPage.Models.Commands.Brands
+@model ChangeBrandLogoDto
+
+<form asp-page="Index" asp-page-handler="ChangeLogoPartial" method="post" enctype="multipart/form-data">
+    <div class="card">
+        <div class="card-header border-bottom border-dashed d-flex align-items-center">
+            <h4 class="header-title">بارگذاری پرونده</h4>
+        </div>
+        <!-- end card-body -->
+        <div class="card-body">
+            <div class="dz-message needsclick">
+                <i class="ti ti-cloud-upload h1 text-muted"></i>
+                <h3>برای بارگذاری کلیک کنید.</h3>
+            </div>
+            <p class="text-muted">
+                برای ویرایش لوگو برند ،فایل مورد نظر را بارگذاری نمایید.
+            </p>
+            <div class="col-lg-6" hidden>
+                @Html.EditorFor(c => c.BrandId)
+            </div>
+            <div class="col-lg-6">
+                @Html.EditorFor(c => c.Logo)
+            </div>
+            <div class="card-footer border-top border-dashed text-end">
+                <div class="d-flex justify-content-end gap-1">
+                    <button type="submit" class="btn btn-primary">ویرایش ‌لوگو</button>
+                    <a data-bs-dismiss="modal" class="btn btn-danger"> لغو</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_Edit.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Brands/_Edit.cshtml
@@ -1,0 +1,37 @@
+﻿@using ShahanStore.RazorPage.Models.Commands.Brands
+@model EditBrandDto
+
+<form asp-page="Index" asp-page-handler="EditPartial" method="post">
+    <div class="card">
+        <div class="card-header border-bottom border-dashed">
+            <h4 class="card-title">اطلاعات مربوط به برند : @Model.Name</h4>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-lg-6" hidden>
+                    @Html.EditorFor(c => c.Id)
+                </div>
+                <div class="col-lg-6">
+                    @Html.EditorFor(c => c.Name)
+                </div>
+                <div class="col-lg-6">
+                    @Html.EditorFor(c => c.Slug)
+                </div>
+                <div class="col-lg-12">
+                    @Html.EditorFor(c => c.Description)
+                </div>
+                @Html.EditorFor(c => c.SeoData)
+                <div class="col-lg-6">
+                    @Html.EditorFor(c => c.IsAvailable)
+                </div>
+            </div>
+        </div>
+
+        <div class="card-footer border-top border-dashed text-end">
+            <div class="d-flex justify-content-end gap-1">
+                <button type="submit" class="btn btn-primary">ویرایش برند</button>
+                <a data-bs-dismiss="modal" class="btn btn-danger"> لغو</a>
+            </div>
+        </div>
+    </div>
+</form>

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Detail.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Detail.cshtml
@@ -2,6 +2,7 @@
 @using ShahanStore.RazorPage.Infrastructure
 @using ShahanStore.RazorPage.Infrastructure.ViewModels
 @using ShahanStore.RazorPage.Infrastructure.ViewModels.Categories
+@using ShahanStore.RazorPage.Models.Bases
 @using ShahanStore.RazorPage.Models.Queries.Categories
 @model ShahanStore.RazorPage.Areas.Admin.Pages.Categories.DetailModel
 @{

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Detail.cshtml.cs
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Detail.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ShahanStore.RazorPage.Infrastructure.RazorUtils;
+using ShahanStore.RazorPage.Models.Bases;
 using ShahanStore.RazorPage.Models.Queries.Categories;
 using ShahanStore.RazorPage.Services.Categories;
 

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Index.cshtml.cs
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Categories/Index.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using ShahanStore.RazorPage.Infrastructure.RazorUtils;
+using ShahanStore.RazorPage.Models.Bases;
 using ShahanStore.RazorPage.Models.Commands.Categories;
 using ShahanStore.RazorPage.Models.Queries.Categories;
 using ShahanStore.RazorPage.Services.Categories;

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Shared/_Pagination.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Shared/_Pagination.cshtml
@@ -1,5 +1,6 @@
-﻿@using ShahanStore.RazorPage.Models.Queries.Categories
-@model CategoryFilterResult
+﻿@using ShahanStore.RazorPage.Models.Bases
+@using ShahanStore.RazorPage.Models.Queries.Categories
+@model BaseFilter
 
 
 <div class="card-footer">

--- a/ShahanStore.RazorPage/Areas/Admin/Pages/Shared/_SideBar.cshtml
+++ b/ShahanStore.RazorPage/Areas/Admin/Pages/Shared/_SideBar.cshtml
@@ -1,216 +1,256 @@
 ﻿<!-- Sidenav Menu Start -->
 <div class="sidenav-menu">
 
-<!-- Brand Logo -->
-<a href="index.html" class="logo">
-    <span class="logo-light">
-        <span class="logo-lg"><img src="/Admin/assets/images/logo.png" alt="logo"></span>
-        <span class="logo-sm text-center"><img src="/Admin/assets/images/logo-sm.png" alt="small logo"></span>
-    </span>
+    <!-- Brand Logo -->
+    <a href="index.html" class="logo">
+        <span class="logo-light">
+            <span class="logo-lg"><img src="/Admin/assets/images/logo.png" alt="logo"></span>
+            <span class="logo-sm text-center"><img src="/Admin/assets/images/logo-sm.png" alt="small logo"></span>
+        </span>
 
-    <span class="logo-dark">
-        <span class="logo-lg"><img src="/Admin/assets/images/logo-dark.png" alt="dark logo"></span>
-        <span class="logo-sm text-center"><img src="/Admin/assets/images/logo-sm.png" alt="small logo"></span>
-    </span>
-</a>
+        <span class="logo-dark">
+            <span class="logo-lg"><img src="/Admin/assets/images/logo-dark.png" alt="dark logo"></span>
+            <span class="logo-sm text-center"><img src="/Admin/assets/images/logo-sm.png" alt="small logo"></span>
+        </span>
+    </a>
 
-<!-- Sidebar Hover Menu Toggle Button -->
-<button class="button-sm-hover">
-    <i class="ti ti-circle align-middle"></i>
-</button>
+    <!-- Sidebar Hover Menu Toggle Button -->
+    <button class="button-sm-hover">
+        <i class="ti ti-circle align-middle"></i>
+    </button>
 
-<!-- Full Sidebar Menu Close Button -->
-<button class="button-close-fullsidebar">
-    <i class="ti ti-x align-middle"></i>
-</button>
+    <!-- Full Sidebar Menu Close Button -->
+    <button class="button-close-fullsidebar">
+        <i class="ti ti-x align-middle"></i>
+    </button>
 
-<div data-simplebar>
+    <div data-simplebar>
 
-    <!--- Sidenav Menu -->
-    <ul class="side-nav">
+        <!--- Sidenav Menu -->
+        <ul class="side-nav">
 
-        <li class="side-nav-item">
-            <a href="index.html" class="side-nav-link">
-                <span class="menu-icon"><i class="ti ti-dashboard"></i></span>
-                <span class="menu-text"> دشبرد</span>
-                <span class="badge bg-success rounded-pill">5</span>
-            </a>
-        </li>
+            <li class="side-nav-item">
+                <a href="index.html" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-dashboard"></i></span>
+                    <span class="menu-text"> دشبرد</span>
+                    <span class="badge bg-success rounded-pill">5</span>
+                </a>
+            </li>
 
-        <li class="side-nav-title mt-2"> اپلیکیشن و صفحات </li>
+            <li class="side-nav-item">
+                <a data-bs-toggle="collapse" href="#sidebarManagement" aria-expanded="false"
+                   aria-controls="sidebarManagement" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-basket-filled"></i></span>
+                    <span class="menu-text"> مدیریت </span>
+                    <span class="menu-arrow"></span>
+                </a>
+                <div class="collapse" id="sidebarManagement">
+                    <ul class="sub-menu">
+                        <li class="side-nav-item">
+                            <a href="/Admin/Categories" class="side-nav-link">
+                                <span class="menu-text"> دسته‌بندی ها </span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="/Admin/Brands" class="side-nav-link">
+                                <span class="menu-text"> برند ها </span>
+                            </a>
+                        </li>
+                        
+                    </ul>
+                </div>
+            </li>
 
-        <li class="side-nav-item">
-            <a data-bs-toggle="collapse" href="#sidebarEcommerce" aria-expanded="false"
-               aria-controls="sidebarEcommerce" class="side-nav-link">
-                <span class="menu-icon"><i class="ti ti-basket-filled"></i></span>
-                <span class="menu-text"> ایکامرس </span>
-                <span class="menu-arrow"></span>
-            </a>
-            <div class="collapse" id="sidebarEcommerce">
-                <ul class="sub-menu">
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-products.html" class="side-nav-link">
-                            <span class="menu-text"> محصولات </span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-products-grid.html" class="side-nav-link">
-                            <span class="menu-text"> شبکه محصولات </span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-product-details.html" class="side-nav-link">
-                            <span class="menu-text"> جزییات محصول </span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-products-add.html" class="side-nav-link">
-                            <span class="menu-text"> افزودن محصول </span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-categories.html" class="side-nav-link">
-                            <span class="menu-text">دسته بندی</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-orders.html" class="side-nav-link">
-                            <span class="menu-text">سفارشات</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-order-details.html" class="side-nav-link">
-                            <span class="menu-text">جزییات سفارش</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-customers.html" class="side-nav-link">
-                            <span class="menu-text">مشتریان</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="apps-ecommerce-sellers.html" class="side-nav-link">
-                            <span class="menu-text">فروشندگان</span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </li>
+           @*  <li class="side-nav-item">
+                <a href="/Admin/Categories" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-dashboard"></i></span>
+                    <span class="menu-text">دسته‌بندی ها</span>
+                    <span class="badge bg-success rounded-pill">5</span>
+                </a>
+            </li>
+
+            <li class="side-nav-item">
+                <a href="/Admin/Brands" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-dashboard"></i></span>
+                    <span class="menu-text">برند ها‌</span>
+                    <span class="badge bg-success rounded-pill">5</span>
+                </a>
+            </li> *@
+
+            <li class="side-nav-title mt-2"> اپلیکیشن و صفحات </li>
+
+            <li class="side-nav-item">
+                <a data-bs-toggle="collapse" href="#sidebarEcommerce" aria-expanded="false"
+                   aria-controls="sidebarEcommerce" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-basket-filled"></i></span>
+                    <span class="menu-text"> ایکامرس </span>
+                    <span class="menu-arrow"></span>
+                </a>
+                <div class="collapse" id="sidebarEcommerce">
+                    <ul class="sub-menu">
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-products.html" class="side-nav-link">
+                                <span class="menu-text"> محصولات </span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-products-grid.html" class="side-nav-link">
+                                <span class="menu-text"> شبکه محصولات </span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-product-details.html" class="side-nav-link">
+                                <span class="menu-text"> جزییات محصول </span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-products-add.html" class="side-nav-link">
+                                <span class="menu-text"> افزودن محصول </span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-categories.html" class="side-nav-link">
+                                <span class="menu-text">دسته بندی</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-orders.html" class="side-nav-link">
+                                <span class="menu-text">سفارشات</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-order-details.html" class="side-nav-link">
+                                <span class="menu-text">جزییات سفارش</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-customers.html" class="side-nav-link">
+                                <span class="menu-text">مشتریان</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="apps-ecommerce-sellers.html" class="side-nav-link">
+                                <span class="menu-text">فروشندگان</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
 
 
-        <li class="side-nav-title mt-2">کامپوننت ها</li>
+            <li class="side-nav-title mt-2">کامپوننت ها</li>
 
-        <li class="side-nav-item">
-            <a data-bs-toggle="collapse" href="#sidebarExtendedUI" aria-expanded="false"
-               aria-controls="sidebarExtendedUI" class="side-nav-link">
-                <span class="menu-icon"><i class="ti ti-alien-filled"></i></span>
-                <span class="menu-text">رابط کاربری پشرفته</span>
-                <span class="menu-arrow"></span>
-            </a>
-            <div class="collapse" id="sidebarExtendedUI">
-                <ul class="sub-menu">
-                    <li class="side-nav-item">
-                        <a href="extended-dragula.html" class="side-nav-link">
-                            <span class="menu-text">دراگولا</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="extended-sweetalerts.html" class="side-nav-link">
-                            <span class="menu-text">سوییت الرت</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="extended-ratings.html" class="side-nav-link">
-                            <span class="menu-text">ریتینگ</span>
-                        </a>
-                    </li>
-                    <li class="side-nav-item">
-                        <a href="extended-scrollbar.html" class="side-nav-link">
-                            <span class="menu-text">اسکرولبار</span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </li>
-
-
-        <li class="side-nav-title mt-2">
-            بیشتر
-        </li>
+            <li class="side-nav-item">
+                <a data-bs-toggle="collapse" href="#sidebarExtendedUI" aria-expanded="false"
+                   aria-controls="sidebarExtendedUI" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-alien-filled"></i></span>
+                    <span class="menu-text">رابط کاربری پشرفته</span>
+                    <span class="menu-arrow"></span>
+                </a>
+                <div class="collapse" id="sidebarExtendedUI">
+                    <ul class="sub-menu">
+                        <li class="side-nav-item">
+                            <a href="extended-dragula.html" class="side-nav-link">
+                                <span class="menu-text">دراگولا</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="extended-sweetalerts.html" class="side-nav-link">
+                                <span class="menu-text">سوییت الرت</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="extended-ratings.html" class="side-nav-link">
+                                <span class="menu-text">ریتینگ</span>
+                            </a>
+                        </li>
+                        <li class="side-nav-item">
+                            <a href="extended-scrollbar.html" class="side-nav-link">
+                                <span class="menu-text">اسکرولبار</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
 
 
-        <li class="side-nav-item">
-            <a data-bs-toggle="collapse" href="#sidebarMultiLevel" aria-expanded="false"
-               aria-controls="sidebarMultiLevel" class="side-nav-link">
-                <span class="menu-icon"><i class="ti ti-box-multiple-3"></i></span>
-                <span class="menu-text"> چند لایه </span>
-                <span class="menu-arrow"></span>
-            </a>
-            <div class="collapse" id="sidebarMultiLevel">
-                <ul class="sub-menu">
-                    <li class="side-nav-item">
-                        <a data-bs-toggle="collapse" href="#sidebarSecondLevel" aria-expanded="false"
-                           aria-controls="sidebarSecondLevel" class="side-nav-link">
-                            <span class="menu-text"> لایه دوم</span>
-                            <span class="menu-arrow"></span>
-                        </a>
-                        <div class="collapse" id="sidebarSecondLevel">
-                            <ul class="sub-menu">
-                                <li class="side-nav-item">
-                                    <a href="javascript: void(0);" class="side-nav-link">
-                                        <span class="menu-text">مورد 1</span>
-                                    </a>
-                                </li>
-                                <li class="side-nav-item">
-                                    <a href="javascript: void(0);" class="side-nav-link">
-                                        <span class="menu-text">مورد 2</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </li>
-                    <li class="side-nav-item">
-                        <a data-bs-toggle="collapse" href="#sidebarThirdLevel" aria-expanded="false"
-                           aria-controls="sidebarThirdLevel" class="side-nav-link">
-                            <span class="menu-text"> لایه سوم</span>
-                            <span class="menu-arrow"></span>
-                        </a>
-                        <div class="collapse" id="sidebarThirdLevel">
-                            <ul class="sub-menu">
-                                <li class="side-nav-item">
-                                    <a href="javascript: void(0);" class="side-nav-link">مورد 1</a>
-                                </li>
-                                <li class="side-nav-item">
-                                    <a data-bs-toggle="collapse" href="#sidebarFourthLevel"
-                                       aria-expanded="false" aria-controls="sidebarFourthLevel"
-                                       class="side-nav-link">
-                                        <span class="menu-text">مورد 2 </span>
-                                        <span class="menu-arrow"></span>
-                                    </a>
-                                    <div class="collapse" id="sidebarFourthLevel">
-                                        <ul class="sub-menu">
-                                            <li class="side-nav-item">
-                                                <a href="javascript: void(0);" class="side-nav-link">
-                                                    <span class="menu-text">مورد 2.1</span>
-                                                </a>
-                                            </li>
-                                            <li class="side-nav-item">
-                                                <a href="javascript: void(0);" class="side-nav-link">
-                                                    <span class="menu-text">مورد 2.2</span>
-                                                </a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </li>
-                            </ul>
-                        </div>
-                    </li>
-                </ul>
-            </div>
-        </li>
-    </ul>
+            <li class="side-nav-title mt-2">
+                بیشتر
+            </li>
 
-    <div class="clearfix"></div>
-</div>
+
+            <li class="side-nav-item">
+                <a data-bs-toggle="collapse" href="#sidebarMultiLevel" aria-expanded="false"
+                   aria-controls="sidebarMultiLevel" class="side-nav-link">
+                    <span class="menu-icon"><i class="ti ti-box-multiple-3"></i></span>
+                    <span class="menu-text"> چند لایه </span>
+                    <span class="menu-arrow"></span>
+                </a>
+                <div class="collapse" id="sidebarMultiLevel">
+                    <ul class="sub-menu">
+                        <li class="side-nav-item">
+                            <a data-bs-toggle="collapse" href="#sidebarSecondLevel" aria-expanded="false"
+                               aria-controls="sidebarSecondLevel" class="side-nav-link">
+                                <span class="menu-text"> لایه دوم</span>
+                                <span class="menu-arrow"></span>
+                            </a>
+                            <div class="collapse" id="sidebarSecondLevel">
+                                <ul class="sub-menu">
+                                    <li class="side-nav-item">
+                                        <a href="javascript: void(0);" class="side-nav-link">
+                                            <span class="menu-text">مورد 1</span>
+                                        </a>
+                                    </li>
+                                    <li class="side-nav-item">
+                                        <a href="javascript: void(0);" class="side-nav-link">
+                                            <span class="menu-text">مورد 2</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="side-nav-item">
+                            <a data-bs-toggle="collapse" href="#sidebarThirdLevel" aria-expanded="false"
+                               aria-controls="sidebarThirdLevel" class="side-nav-link">
+                                <span class="menu-text"> لایه سوم</span>
+                                <span class="menu-arrow"></span>
+                            </a>
+                            <div class="collapse" id="sidebarThirdLevel">
+                                <ul class="sub-menu">
+                                    <li class="side-nav-item">
+                                        <a href="javascript: void(0);" class="side-nav-link">مورد 1</a>
+                                    </li>
+                                    <li class="side-nav-item">
+                                        <a data-bs-toggle="collapse" href="#sidebarFourthLevel"
+                                           aria-expanded="false" aria-controls="sidebarFourthLevel"
+                                           class="side-nav-link">
+                                            <span class="menu-text">مورد 2 </span>
+                                            <span class="menu-arrow"></span>
+                                        </a>
+                                        <div class="collapse" id="sidebarFourthLevel">
+                                            <ul class="sub-menu">
+                                                <li class="side-nav-item">
+                                                    <a href="javascript: void(0);" class="side-nav-link">
+                                                        <span class="menu-text">مورد 2.1</span>
+                                                    </a>
+                                                </li>
+                                                <li class="side-nav-item">
+                                                    <a href="javascript: void(0);" class="side-nav-link">
+                                                        <span class="menu-text">مورد 2.2</span>
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+        </ul>
+
+        <div class="clearfix"></div>
+    </div>
 </div>
 <!-- Sidenav Menu End -->

--- a/ShahanStore.RazorPage/Infrastructure/AppDirectories.cs
+++ b/ShahanStore.RazorPage/Infrastructure/AppDirectories.cs
@@ -4,4 +4,7 @@ public class AppDirectories
 {
     public const string CategoryBanner = "Images/Categories/Banners";
     public const string CategoryIcon = "Images/Categories/Icons";
+
+    public const string BrandBanner = "Images/Brands/Banners";
+    public const string BrandLogo = "Images/Brands/Logos";
 }

--- a/ShahanStore.RazorPage/Infrastructure/DependencyInjection.cs
+++ b/ShahanStore.RazorPage/Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using ShahanStore.RazorPage.Services.Categories;
+﻿using ShahanStore.RazorPage.Services.Brands;
+using ShahanStore.RazorPage.Services.Categories;
 using System.Configuration;
 
 namespace ShahanStore.RazorPage.Infrastructure;
@@ -10,6 +11,12 @@ public static class DependencyInjection
     {
         
         services.AddHttpClient<ICategoryService, CategoryService>(httpClient =>
+        {
+            string? baseAddress = configuration.GetValue<string>("ApiService:BaseUrl");
+            httpClient.BaseAddress = new Uri(baseAddress!);
+        });
+
+        services.AddHttpClient<IBrandService, BrandService>(httpClient =>
         {
             string? baseAddress = configuration.GetValue<string>("ApiService:BaseUrl");
             httpClient.BaseAddress = new Uri(baseAddress!);

--- a/ShahanStore.RazorPage/Infrastructure/ViewModels/Brands/BrandTableRowVM.cs
+++ b/ShahanStore.RazorPage/Infrastructure/ViewModels/Brands/BrandTableRowVM.cs
@@ -1,0 +1,34 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Queries.Brands;
+using ShahanStore.RazorPage.Utilities.Brands;
+
+namespace ShahanStore.RazorPage.Infrastructure.ViewModels.Brands;
+
+public class BrandTableRowVM : IBrandTableRow
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset CreationDate { get; set; }
+    public string Name { get; set; }
+    public string Slug { get; set; }
+    public string? BannerImg { get; set; }
+    public string? Logo { get; set; }
+    public string? Description { get; set; }
+    public bool IsAvailable { get; set; }
+    public SeoDataDto SeoData { get; set; }
+
+    public static BrandTableRowVM FromBrandDto(BrandDto brand)
+    {
+        return new BrandTableRowVM()
+        {
+            Id = brand.Id,
+            CreationDate = brand.CreationDate,
+            Name = brand.Name,
+            Slug = brand.Slug,
+            BannerImg = brand.BannerImg,
+            Logo = brand.Logo,
+            Description= brand.Description,
+            IsAvailable = brand.IsAvailable,
+            SeoData = brand.SeoData,
+        };
+    }
+}

--- a/ShahanStore.RazorPage/Models/Bases/Status.cs
+++ b/ShahanStore.RazorPage/Models/Bases/Status.cs
@@ -1,0 +1,7 @@
+﻿namespace ShahanStore.RazorPage.Models.Bases;
+
+public enum Status
+{
+    Active,
+    NotActive
+}

--- a/ShahanStore.RazorPage/Models/Commands/Brands/ChangeBrandBannerDto.cs
+++ b/ShahanStore.RazorPage/Models/Commands/Brands/ChangeBrandBannerDto.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ShahanStore.RazorPage.Models.Commands.Brands;
+
+public class ChangeBrandBannerDto
+{
+    [Required]
+    public Guid BrandId { get; set; }
+
+
+    [Display(Name = "بنر")]
+    [Required(ErrorMessage = "بنر را وارد کنید!")]
+    public IFormFile BannerImg { get; set; }
+}

--- a/ShahanStore.RazorPage/Models/Commands/Brands/ChangeBrandLogoDto.cs
+++ b/ShahanStore.RazorPage/Models/Commands/Brands/ChangeBrandLogoDto.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ShahanStore.RazorPage.Models.Commands.Brands;
+
+public class ChangeBrandLogoDto
+{
+    [Required]
+    public Guid BrandId { get; set; }
+
+
+    [Display(Name = "لوگو")]
+    [Required(ErrorMessage = "لوگو را وارد کنید!")]
+    public IFormFile Logo { get; set; }
+}

--- a/ShahanStore.RazorPage/Models/Commands/Brands/CreateBrandDto.cs
+++ b/ShahanStore.RazorPage/Models/Commands/Brands/CreateBrandDto.cs
@@ -1,0 +1,31 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+using System.ComponentModel.DataAnnotations;
+
+namespace ShahanStore.RazorPage.Models.Commands.Brands;
+
+public class CreateBrandDto
+{
+    [Display(Name = "عنوان")]
+    [Required(ErrorMessage = "عنوان را وارد کنید!")]
+    public string Name { get; set; }
+
+
+    [Display(Name = "عنوان")]
+    [Required(ErrorMessage = "عنوان را وارد کنید!")]
+    public string Slug { get; set; }
+
+
+    [Display(Name = "بنر")]
+    public IFormFile? BannerImg { get; set; }
+
+
+    [Display(Name = "لوگو")]
+    public IFormFile? Logo { get; set; }
+
+
+    [Display(Name = "توضیحات")]
+    public string? Description { get; set; }
+
+
+    public SeoDataDto SeoData { get; set; }
+}

--- a/ShahanStore.RazorPage/Models/Commands/Brands/DeleteBrandDto.cs
+++ b/ShahanStore.RazorPage/Models/Commands/Brands/DeleteBrandDto.cs
@@ -1,0 +1,3 @@
+﻿namespace ShahanStore.RazorPage.Models.Commands.Brands;
+
+public sealed record DeleteBrandDto(Guid BrandId);

--- a/ShahanStore.RazorPage/Models/Commands/Brands/EditBrandDto.cs
+++ b/ShahanStore.RazorPage/Models/Commands/Brands/EditBrandDto.cs
@@ -1,0 +1,30 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+using System.ComponentModel.DataAnnotations;
+
+namespace ShahanStore.RazorPage.Models.Commands.Brands;
+
+public class EditBrandDto
+{
+
+    [Required]
+    public Guid Id { get; set; }
+
+    [Display(Name = "عنوان")]
+    [Required(ErrorMessage = "عنوان را وارد کنید!")]
+    public string Name { get; set; }
+
+
+    [Display(Name = "عنوان")]
+    [Required(ErrorMessage = "عنوان را وارد کنید!")]
+    public string Slug { get; set; }
+
+
+    [Display(Name = "توضیحات")]
+    public string? Description { get; set; }
+
+
+    [Display(Name = "فعال")]
+    public bool IsAvailable { get; set; }
+
+    public SeoDataDto SeoData { get; set; }
+}

--- a/ShahanStore.RazorPage/Models/Queries/Brands/BrandDto.cs
+++ b/ShahanStore.RazorPage/Models/Queries/Brands/BrandDto.cs
@@ -1,0 +1,15 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+
+namespace ShahanStore.RazorPage.Models.Queries.Brands;
+
+public sealed record BrandDto(
+    Guid Id,
+    DateTimeOffset CreationDate,
+    string Name,
+    string Slug,
+    string? BannerImg,
+    string? Logo,
+    string? Description,
+    bool IsAvailable,
+    SeoDataDto SeoData) : BaseDto(Id, CreationDate);
+

--- a/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterData.cs
+++ b/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterData.cs
@@ -1,0 +1,11 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+
+namespace ShahanStore.RazorPage.Models.Queries.Brands;
+
+public sealed record BrandFilterData(
+    Guid Id,
+    DateTimeOffset CreationDate,
+    string Name,
+    string Slug,
+    string? Logo,
+    bool IsAvailable) : BaseDto(Id, CreationDate);

--- a/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterParams.cs
+++ b/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterParams.cs
@@ -1,10 +1,8 @@
 ﻿using ShahanStore.RazorPage.Models.Bases;
 
-namespace ShahanStore.RazorPage.Models.Queries.Categories;
+namespace ShahanStore.RazorPage.Models.Queries.Brands;
 
-public sealed record CategoryFilterParams(
-    //Guid? CategoryId,
-    //string? Slug,
+public sealed record BrandFilterParams(
     string? Search,
     Status? Status,
     int PageId = 1,

--- a/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterResult.cs
+++ b/ShahanStore.RazorPage/Models/Queries/Brands/BrandFilterResult.cs
@@ -1,0 +1,7 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+
+namespace ShahanStore.RazorPage.Models.Queries.Brands;
+
+public class BrandFilterResult : BaseFilter<BrandFilterData, BrandFilterParams>
+{
+}

--- a/ShahanStore.RazorPage/Services/Brands/BrandService.cs
+++ b/ShahanStore.RazorPage/Services/Brands/BrandService.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Commands.Brands;
+using ShahanStore.RazorPage.Models.Queries.Brands;
+
+namespace ShahanStore.RazorPage.Services.Brands;
+
+internal sealed class BrandService(HttpClient client, ILogger<BrandService> logger) : IBrandService
+{
+
+    #region Commands
+    public async Task<ApiResult> CreateBrand(CreateBrandDto createDto)
+    {
+        using var formData = createDto.ToMultipartFormData();
+        var response = await client.PostAsync("Brand", formData);
+        return await response.ToApiResult();
+    }
+
+    public async Task<ApiResult> EditBrand(EditBrandDto editDto)
+    {
+        using var formData = editDto.ToMultipartFormData();
+        var response = await client.PutAsync("Brand", formData);
+        return await response.ToApiResult();
+    }
+
+    public async Task<ApiResult> DeleteBrand(Guid id)
+    {
+        var response = await client.DeleteAsync($"Brand/{id}");
+        return await response.ToApiResult();
+    }
+
+    public async Task<ApiResult> ChangeBanner(ChangeBrandBannerDto changeBannerDto)
+    {
+        using var formData = changeBannerDto.ToMultipartFormData();
+        var response = await client.PutAsync("Brand/ChangeBanner", formData);
+        return await response.ToApiResult();
+    }
+
+    public async Task<ApiResult> ChangeLogo(ChangeBrandLogoDto changeLogoDto)
+    {
+        using var formData = changeLogoDto.ToMultipartFormData();
+        var response = await client.PutAsync("Brand/ChangeLogo", formData);
+        return await response.ToApiResult();
+    }
+
+    #endregion
+
+
+    #region Queries
+    public async Task<BrandFilterResult> GetByFilter(BrandFilterParams filterParams)
+    {
+        var queryParams = new Dictionary<string, string>();
+        queryParams.Add("pageId", filterParams.PageId.ToString());
+        queryParams.Add("take", filterParams.Take.ToString());
+
+
+        if (!string.IsNullOrWhiteSpace(filterParams.Search))
+            queryParams.Add("search", filterParams.Search);
+
+        if (filterParams.Status != null)
+            queryParams.Add("status", filterParams.Status.ToString());
+
+        var url = QueryHelpers.AddQueryString("Brand/filter", queryParams);
+
+        try
+        {
+            var result = await client.GetFromJsonAsync<ApiResult<BrandFilterResult>>(url);
+            if (result == null || result.Data == null)
+            {
+                return new BrandFilterResult { Data = new List<BrandFilterData>() };
+            }
+
+            return result.Data;
+        }
+        catch (Exception ex)
+        {
+
+            logger.LogError(ex, "Failed to fetch Categories from API.");
+            return new BrandFilterResult { Data = new List<BrandFilterData>() };
+        }
+    }
+
+    public async Task<BrandDto> GetById(Guid id)
+    {
+        var result = await client.GetFromJsonAsync<ApiResult<BrandDto>>($"Brand/{id}");
+        return result.Data;
+    }
+
+    public async Task<BrandDto> GetBySlug(string slug)
+    {
+        var result = await client.GetFromJsonAsync<ApiResult<BrandDto>>($"Brand/{slug}");
+        return result.Data;
+    }
+    #endregion
+} 

--- a/ShahanStore.RazorPage/Services/Brands/IBrandService.cs
+++ b/ShahanStore.RazorPage/Services/Brands/IBrandService.cs
@@ -1,0 +1,25 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+using ShahanStore.RazorPage.Models.Commands.Brands;
+using ShahanStore.RazorPage.Models.Queries.Brands;
+
+namespace ShahanStore.RazorPage.Services.Brands;
+
+public interface IBrandService
+{
+    #region Commands
+    Task<ApiResult> CreateBrand(CreateBrandDto createDto);
+    Task<ApiResult> EditBrand(EditBrandDto editDto);
+    Task<ApiResult> DeleteBrand(Guid id);
+    Task<ApiResult> ChangeBanner(ChangeBrandBannerDto changeBannerDto);
+    Task<ApiResult> ChangeLogo(ChangeBrandLogoDto changeLogoDto);
+
+    #endregion
+
+
+    #region Queries
+    Task<BrandFilterResult> GetByFilter(BrandFilterParams filterParams);
+    Task<BrandDto> GetById(Guid id);
+    Task<BrandDto> GetBySlug(string slug);
+
+    #endregion
+}

--- a/ShahanStore.RazorPage/Services/Categories/CategoryService.cs
+++ b/ShahanStore.RazorPage/Services/Categories/CategoryService.cs
@@ -35,8 +35,8 @@ public class CategoryService(HttpClient client, ILogger<CategoryService> logger)
 
     public async Task<ApiResult> DeleteCategory(Guid id)
     {
-        var result = await client.DeleteAsync($"Category/{id}");
-        return await result.Content.ReadFromJsonAsync<ApiResult>();
+        var response = await client.DeleteAsync($"Category/{id}");
+        return await response.ToApiResult();
     }
 
 

--- a/ShahanStore.RazorPage/Utilities/Brands/IBrandTableRow.cs
+++ b/ShahanStore.RazorPage/Utilities/Brands/IBrandTableRow.cs
@@ -1,0 +1,16 @@
+﻿using ShahanStore.RazorPage.Models.Bases;
+
+namespace ShahanStore.RazorPage.Utilities.Brands;
+
+public interface IBrandTableRow
+{
+    public Guid Id { get; }
+    public DateTimeOffset CreationDate { get; }
+    public string Name { get; }
+    public string Slug { get; }
+    public string? BannerImg { get; }
+    public string? Logo { get; }
+    public string? Description { get; }
+    public bool IsAvailable { get; }
+    public SeoDataDto SeoData { get; }
+}


### PR DESCRIPTION
This commit introduces the complete set of CRUD (Create, Read, Update, Delete) pages for managing brands in the admin panel. Following the pattern established for categories, this provides administrators with the necessary UI to create, edit, and delete brand entries.

- **Presentation Layer:**
  - Added `Create.cshtml` and its PageModel to handle the creation of new brands, including form binding and validation.
  - Added `Edit.cshtml` and its PageModel for fetching and updating the details of existing brands.
  - Created an `Index.cshtml` page to display a paginated list of all brands, with links to Edit and a modal-based deletion feature.
  - Implemented a reusable delete confirmation modal to prevent accidental data loss.

- **Core Layer:**
  - Created `CreateBrandViewModel` and `EditBrandViewModel` to ensure a clean separation between domain logic and presentation data, handling validation rules specific to brands.

- **Infrastructure Layer:**
  - Updated the admin navigation sidebar to include a link to the new brand management section.